### PR TITLE
Updated Dockerfile to use fixed Python version at 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.12
 
 COPY . /workspace
 WORKDIR /workspace


### PR DESCRIPTION
For `audioop` support, a package which was [deprecated in 3.11 and removed in 3.13](https://docs.python.org/3/library/audioop.html).